### PR TITLE
updated to use the lastest version of analytics-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=5.5.9",
         "illuminate/config": "5.1.*|5.2.*|5.3.*",
         "illuminate/support": "5.1.*|5.2.*|5.3.*",
-        "segmentio/analytics-php": "1.2.*"
+        "segmentio/analytics-php": "1.3.*"
     },
     "require-dev": {
         "graham-campbell/testbench": "^3.1",


### PR DESCRIPTION
This pull is made so we can use the latest version of the framework, instead of being lock down to version 1.2
